### PR TITLE
Fixes for s6-overlay v3

### DIFF
--- a/beta/rootfs/etc/services.d/almond/finish
+++ b/beta/rootfs/etc/services.d/almond/finish
@@ -5,4 +5,4 @@
 if { s6-test ${1} -ne 0 }
 if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+/run/s6/basedir/bin/halt

--- a/beta/rootfs/etc/services.d/nginx/finish
+++ b/beta/rootfs/etc/services.d/nginx/finish
@@ -5,4 +5,4 @@
 if { s6-test ${1} -ne 0 }	
 if { s6-test ${1} -ne 256 }	
 
-s6-svscanctl -t /var/run/s6/services
+/run/s6/basedir/bin/halt

--- a/edge/rootfs/etc/services.d/almond/finish
+++ b/edge/rootfs/etc/services.d/almond/finish
@@ -5,4 +5,4 @@
 if { s6-test ${1} -ne 0 }
 if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+/run/s6/basedir/bin/halt

--- a/edge/rootfs/etc/services.d/nginx/finish
+++ b/edge/rootfs/etc/services.d/nginx/finish
@@ -5,4 +5,4 @@
 if { s6-test ${1} -ne 0 }	
 if { s6-test ${1} -ne 256 }	
 
-s6-svscanctl -t /var/run/s6/services
+/run/s6/basedir/bin/halt


### PR DESCRIPTION
Replaced s6-svscanctl in finish script and made scripts executable per https://github.com/just-containers/s6-overlay/blob/master/MOVING-TO-V3.md

This fixes #18